### PR TITLE
Allow token use in insecure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Available Commands:
 
 Flags:
   -C, --api-crt string            Path to SSL crt for API access
+  -a, --api-domain string         Domain of generated cert (if none passed) (default "shaman.nanobox.io")
   -k, --api-key string            Path to SSL key for API access
   -p, --api-key-password string   Password for SSL key
   -H, --api-listen string         Listen address for the API (ip:port) (default "127.0.0.1:1632")
@@ -78,6 +79,7 @@ An optional config file can also be passed on startup:
 >config.json
 >```json
 >{
+>  "api-domain": "shaman.nanobox.io",
 >  "api-crt": "",
 >  "api-key": "",
 >  "api-key-password": "",

--- a/api/api.go
+++ b/api/api.go
@@ -32,24 +32,26 @@ var (
 
 // Start starts shaman's http api
 func Start() error {
+	auth.Header = "X-AUTH-TOKEN"
+
 	// handle config.Insecure
 	if config.Insecure {
 		config.Log.Info("Shaman listening at http://%s...", config.ApiListen)
-		return fmt.Errorf("API stopped - %v", http.ListenAndServe(config.ApiListen, routes()))
+		return fmt.Errorf("API stopped - %v", auth.ListenAndServe(config.ApiListen, config.ApiToken, routes()))
 	}
 
 	var cert *tls.Certificate
 	var err error
 	if config.ApiCrt == "" {
-		cert, err = nanoauth.Generate("shaman.nanobox.io")
+		cert, err = nanoauth.Generate(config.ApiDomain)
 	} else {
 		cert, err = nanoauth.Load(config.ApiCrt, config.ApiKey, config.ApiKeyPassword)
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to generate or load cert - %s", err.Error())
 	}
+
 	auth.Certificate = cert
-	auth.Header = "X-AUTH-TOKEN"
 
 	config.Log.Info("Shaman listening at https://%v", config.ApiListen)
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	ApiDomain          = "shaman.nanobox.io"         // Domain for generating cert (if none passed)
 	ApiCrt             = ""                          // Path to SSL crt for API access
 	ApiKey             = ""                          // Path to SSL key for API access
 	ApiKeyPassword     = ""                          // Password for SSL key
@@ -34,6 +35,7 @@ var (
 // AddFlags adds the available cli flags
 func AddFlags(cmd *cobra.Command) {
 	// api
+	cmd.Flags().StringVarP(&ApiDomain, "api-domain", "a", ApiDomain, "Domain of generated cert (if none passed)")
 	cmd.Flags().StringVarP(&ApiCrt, "api-crt", "C", ApiCrt, "Path to SSL crt for API access")
 	cmd.Flags().StringVarP(&ApiKey, "api-key", "k", ApiKey, "Path to SSL key for API access")
 	cmd.Flags().StringVarP(&ApiKeyPassword, "api-key-password", "p", ApiKeyPassword, "Password for SSL key")
@@ -62,6 +64,7 @@ func LoadConfigFile() error {
 	}
 
 	// Set defaults to whatever might be there already
+	viper.SetDefault("api-domain", ApiDomain)
 	viper.SetDefault("api-crt", ApiCrt)
 	viper.SetDefault("api-key", ApiKey)
 	viper.SetDefault("api-key-password", ApiKeyPassword)
@@ -85,6 +88,7 @@ func LoadConfigFile() error {
 	}
 
 	// Set values. Config file will override commandline
+	ApiDomain = viper.GetString("api-domain")
 	ApiCrt = viper.GetString("api-crt")
 	ApiKey = viper.GetString("api-key")
 	ApiKeyPassword = viper.GetString("api-key-password")

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -191,10 +191,10 @@
 			"revisionTime": "2018-02-03T10:28:30Z"
 		},
 		{
-			"checksumSHA1": "1GRIFd6tEXuuQll7oav7S3UdYE0=",
+			"checksumSHA1": "vl8zkek51ZtDVH8/QuCrieZd4j4=",
 			"path": "github.com/nanobox-io/golang-nanoauth",
-			"revision": "d48ad8ddeaf0cc843f887bbb78cd05e79cc1d669",
-			"revisionTime": "2016-10-26T18:18:52Z"
+			"revision": "3397bf18cb420ef8278a0d5b3572de6b39aa7360",
+			"revisionTime": "2018-03-13T01:03:18Z"
 		},
 		{
 			"checksumSHA1": "nzROOnBgMd8I+TknYTTgIAnvW70=",


### PR DESCRIPTION
Setting the token to and empty string (`""`) in the configuration will disable the token. Starting shaman in `insecure` mode will use the token configured.
The common name associated with the generated cert is also now configurable (`-a "new-domain.com"`) 

**Note:** There is a token configured by default. If, after updating, you are getting `401`s, try using the `x-auth-token: secret`